### PR TITLE
Add AMD GPU support with libva

### DIFF
--- a/Dockerfile.amd64.goreleaser
+++ b/Dockerfile.amd64.goreleaser
@@ -17,7 +17,7 @@ RUN CAESIUM_LATEST_RELEASE=$(curl -s https://api.github.com/repos/$CAESIUM_GITHU
 FROM jlesage/handbrake:latest
 
 RUN apk update
-RUN apk add jq curl vips-tools exiftool ffmpeg imagemagick libc6-compat libjxl-tools libheif libde265
+RUN apk add jq curl vips-tools exiftool ffmpeg imagemagick libc6-compat libjxl-tools libheif libde265 libva libva-utils mesa-va-gallium
 
 COPY --from=builder /usr/local/bin/caesiumclt /usr/local/bin/caesiumclt
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -18,7 +18,7 @@ FROM debian:sid-slim
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y install jq curl libjxl-tools libvips-tools exiftool
-RUN DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -qq -y install handbrake-cli ffmpeg imagemagick
+RUN DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends -qq -y install handbrake-cli ffmpeg imagemagick vainfo libva2 libva-drm2 mesa-va-drivers
 
 COPY --from=builder /usr/local/bin/caesiumclt /usr/local/bin/caesiumclt
 

--- a/config/storage-saver-amd-gpu/tasks.yaml
+++ b/config/storage-saver-amd-gpu/tasks.yaml
@@ -1,0 +1,66 @@
+tasks:
+  # Images: Resize to max 16MP, encode to JXL, restore metadata
+  - name: images-magick-jxl
+    command: >
+      magick "{{.folder}}/{{.name}}.{{.extension}}"
+      -auto-orient
+      -resize 4096x4096\>
+      ppm:- |
+      cjxl - "{{.folder}}/{{.name}}-new.jxl"
+      -q 80
+      --effort=7
+      && exiftool -overwrite_original
+      -tagsfromfile "{{.folder}}/{{.name}}.{{.extension}}"
+      -all:all -m -Orientation=1 "{{.folder}}/{{.name}}-new.jxl"
+      && rm "{{.folder}}/{{.name}}.{{.extension}}"
+    extensions:
+      - avif
+      - bmp
+      - gif
+      - heic
+      - heif
+      - jpeg
+      - jpg
+      - png
+      - tiff
+      - tif
+      - webp
+
+  # Videos: ffmpeg with hwaccel from AMD iGPU.
+  - name: videos-ffmpeg
+    command: >
+      ffmpeg
+      -hwaccel vaapi
+      -hwaccel_device /dev/dri/renderD128
+      -i "{{.folder}}/{{.name}}.{{.extension}}"
+      -vf "scale='if(gt(iw,ih),min(1920,iw),-2)':'if(gt(ih,iw),min(1920,ih),-2)':flags=lanczos,format=p010,hwupload"
+      -c:v hevc_vaapi -profile:v main10 -qp 22
+      -c:a libopus -b:a 128k
+      "{{.folder}}/{{.name}}-new.mp4"
+      && exiftool -overwrite_original
+      -tagsfromfile "{{.folder}}/{{.name}}.{{.extension}}"
+      -all:all -m -Orient "{{.folder}}/{{.name}}-new.mp4"
+      &&
+      rm "{{.folder}}/{{.name}}.{{.extension}}"
+    extensions:
+      - 3gp
+      - 3gpp
+      - avi
+      - av1
+      - flv
+      - hevc
+      - insv
+      - m2t
+      - m2ts
+      - m4v
+      - mkv
+      - mod
+      - mov
+      - mpe
+      - mpg
+      - mp4
+      - mts
+      - tod
+      - ts
+      - webm
+      - wmv


### PR DESCRIPTION
This enables Intel/AMD iGPU hardware acceleration for video encoding (e.g., on Ryzen 5825u CPU which is popular on NAS hardwares).