### PR TITLE
Fix redirecting detection for immich mobile apps

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -18,10 +18,12 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) (err e
 
 	// Check if client has broken redirect behavior, like the android app.
 	// Redirect support is necessary as file processing can take a long time and the client risks a timeout on the http request.
-	// Currently no way to check for redirect support so blacklist these user agents.
-	// Ideally redirect support is added here: https://github.com/immich-app/immich/blob/f6cbc9db06c0783d09f154f66e12d041032fff62/cli/src/commands/asset.ts#L290
+	// Prefer an explicit `Accept` header indicating an HTML-capable client (browser).
+	// Fallback to a blacklist for known clients with broken redirect behavior.
+	acceptHeader := r.Header.Get("Accept")
+	clientFollowsRedirects := strings.Contains(acceptHeader, "text/html")
+
 	brokenRedirectUserAgents := []string{"Dart/", "Dalvik/", "Immich"}
-	clientFollowsRedirects := true
 	for _, userAgent := range brokenRedirectUserAgents {
 		if strings.HasPrefix(r.UserAgent(), userAgent) {
 			clientFollowsRedirects = false


### PR DESCRIPTION
Improve detection for redirecting by checking Accept header so we can detect the immich mobile apps directly.

Fully selftested. Fixes #53 and probably #52

This resolves the bug that the mobile apps doesnt receive an response so upload isnt working properly. Adding "Immich" to the blacklist hasnt fixed this. 